### PR TITLE
Add cursor: pointer to the original checkboxes and radios

### DIFF
--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -21,6 +21,7 @@
 .control input {
   position: absolute;
   opacity: 0;
+  cursor: pointer;
 }
 .control-indicator {
   position: absolute;


### PR DESCRIPTION
When hovering the "hidden" checkboxes, the cursor reverts to the default.
