### PR TITLE
Improvements for select element on Firefox

### DIFF
--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -91,7 +91,7 @@
           appearance: none;
 }
 /* Undo the Firefox inner focus ring */
-.select select:-moz-focusring {
+.select select:focus:-moz-focusring {
   color: transparent;
   text-shadow: 0 0 0 #000;
 }


### PR DESCRIPTION
This PR address two issues:

1- `<option>` elements inherit styles from `<select>` elements, so we are reseting the options to have a white background on FF:

Before:
![click-before](https://cloud.githubusercontent.com/assets/766837/2956198/17b63c32-da8b-11e3-89be-f0889cd96d60.png)

After:
![click-after](https://cloud.githubusercontent.com/assets/766837/2956192/039ef20c-da8b-11e3-98a3-4a00197ea2f9.png)

2- `-moz-focusring` is now placed under `focus` state, so dragging the element to select an option looks good as well:

Before:
![drag-before](https://cloud.githubusercontent.com/assets/766837/2956201/2917d080-da8b-11e3-8b22-c46f94e8210d.png)

After:
![drag-after](https://cloud.githubusercontent.com/assets/766837/2956207/363e38c6-da8b-11e3-826c-c344eec39fb0.png)
