### PR TITLE
Moved up user-select none to `.control`

### DIFF
--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -17,6 +17,10 @@
   padding-left: 1.5rem;
   color: #555;
   cursor: pointer;
+  -webkit-user-select: none;
+     -moz-user-select: none;
+      -ms-user-select: none;
+          user-select: none;
 }
 .control input {
   position: absolute;
@@ -34,10 +38,6 @@
   color: #eee;
   text-align: center;
   background-color: #eee;
-  -webkit-user-select: none;
-     -moz-user-select: none;
-      -ms-user-select: none;
-          user-select: none;
 }
 
 /* Hover state */


### PR DESCRIPTION
To ensure that the label doesn't get a selected / highlighted
state when toggling form controls e.g. https://dl.dropboxusercontent.com/u/391082/user-select.mov
