### PR TITLE
Showing filenames where possible

### DIFF
--- a/index.html
+++ b/index.html
@@ -172,13 +172,13 @@
 
 <form class="controls-stacked">
   <label class="file">
-  <input type="file" id="file">
-  <span class="file-custom"></span>
-</label>
+    <input type="file" id="file">
+    <span class="file-custom" data-button-text="Browse" data-placeholder-fallback="Choose file..."></span>
+  </label>
 </form>
 <div class="highlight"><pre><code class="language-html" data-lang="html"><span class="nt">&lt;label</span> <span class="na">class=</span><span class="s">&quot;file&quot;</span><span class="nt">&gt;</span>
   <span class="nt">&lt;input</span> <span class="na">type=</span><span class="s">&quot;file&quot;</span> <span class="na">id=</span><span class="s">&quot;file&quot;</span><span class="nt">&gt;</span>
-  <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">&quot;file-custom&quot;</span><span class="nt">&gt;&lt;/span&gt;</span>
+  <span class="nt">&lt;span</span> <span class="na">class=</span><span class="s">&quot;file-custom&quot;</span> <span class="na">data-button-text=</span><span class="s">&quot;Browse&quot;</span> <span class="na">data-placeholder-fallback=</span><span class="s">&quot;Choose file...&quot;</span><span class="nt">&gt;&lt;/span&gt;</span>
 <span class="nt">&lt;/label&gt;</span>
 </code></pre></div>
 <p>The file input is the most gnarly of the bunch. Here&#39;s how it works:</p>

--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -216,20 +216,28 @@
   cursor: pointer;
   height: 2.5rem;
 }
+
 .file input {
-  min-width: 14rem;
+  position: relative;
+  top: 50%;
+  width: 69%;
+  z-index: 6;
+  line-height: 1;
+  vertical-align: top;
   margin: 0;
-  filter: alpha(opacity=0);
-  opacity: 0;
+  padding-left: .5rem;
+  -webkit-transform: translate(0, -50%);
+      -ms-transform: translate(0, -50%);
+          transform: translate(0, -50%);
 }
+
 .file-custom {
   position: absolute;
   top: 0;
   right: 0;
+  bottom: 0;
   left: 0;
   z-index: 5;
-  height: 2.5rem;
-  padding: .5rem 1rem;
   line-height: 1.5;
   color: #555;
   background-color: #fff;
@@ -241,32 +249,101 @@
       -ms-user-select: none;
           user-select: none;
 }
-.file-custom:after {
-  content: "Choose file...";
-}
+
 .file-custom:before {
   position: absolute;
+  width: 29%;
   top: -.075rem;
   right: -.075rem;
   bottom: -.075rem;
   z-index: 6;
-  display: block;
-  content: "Browse";
+  content: attr(data-button-text);
   height: 2.5rem;
-  padding: .5rem 1rem;
+  padding: .5rem;
   line-height: 1.5;
   color: #555;
   background-color: #eee;
   border: .075rem solid #ddd;
   border-radius: 0 .25rem .25rem 0;
+  text-align: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.file ::-webkit-file-upload-button {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
+}
+
+.file ::-ms-browse {
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  padding: 0;
+  border: 0;
 }
 
 /* Focus */
+.file input:focus {
+  outline: 0;
+}
+
 .file input:focus ~ .file-custom {
   box-shadow: 0 0 0 .075rem #fff, 0 0 0 .2rem #0074d9;
 }
 
+/* firefox specific hack, hide the file input, show custom element */
+@-moz-document url-prefix() {
+  .file input {
+    opacity: 0;
+  }
 
+  .file-custom:after {
+    content: attr(data-placeholder-fallback);
+    position: relative;
+    display: inline-block;
+    top: 50%;
+    left: .5rem;
+    transform: translate(0, -50%);
+  }
+
+  .file-custom:before {
+    top: -0.05rem;
+  }
+}
+
+
+/* IE9+ */
+@media screen and (min-width:0\0) {
+  .file input {
+    background-color: transparent;
+    direction: rtl;
+    height: auto;
+  }
+
+  /* ideally we would only show this in IE9 but the \0/ hack used below doesn't seem to work for every property including content */
+  .file-custom:after {
+    content: attr(data-placeholder-fallback);
+    position: relative;
+    display: inline-block;
+    top: 50%;
+    left: .5rem;
+    -ms-transform: translate(0, -50%);
+    transform: translate(0, -50%);
+  }
+
+}
+
+/* IE9 show custom element by hiding the file input */
+.file input {
+  height: 0 \0/;
+  opacity: 0 \0/;
+  filter: alpha(opacity=0) \0/;
+}
 
 /*
  * Control layouts


### PR DESCRIPTION
This is my attempt to satisfy issues #1 and is coincidentally related to #21 because I wanted to avoid repetition.
It shows uploaded filenames in webkit browsers and ie10+, "gracefully" falling back to the previous styles (text "Choose file..." not being updated) where not possible.
## Summary of changes:
- showing the original file input field in webkit and ie10+ and hiding the button via pseudo-selectors
- falling back to hiding file input and showing our custom element in firefox and ie9 where pseudo-selectors are not available
- fixed width of input and button to not have overlapping content when either the button text or the name of the selected file is too long
- adjusted paddings a little for a more even look of space between uploaded filename and button
- moved button text and placeholder text to data attributes to help with translations and avoid repetition
- removed default outline of focussed input

Tested and working in Chrome 34.0.1847.137, Opera 21.0.1432.67, Firefox 29.0.1, IE9, IE11

It is suggested that you specify a width for `<label class="file">` for optimum cross-browser rendering, otherwise it will appear a lot more narrow in IE than in other browsers.
This can be achieved also by using e.g. bootstrap column classes.

disclaimer: when I say ie10+ it is actually untested in ie10 (currently don't have a vm for that at hand) but works in ie11 and I expect it to work in ie10 as well (first version to introduce the pseudo-selector which is used to hide the default button)
