### PR TITLE
Added style for disabled controls

### DIFF
--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -72,6 +72,11 @@
   background-color: #84c6ff;
 }
 
+/* Disabled */
+.control input:disabled ~ .control-indicator {
+  background-color: #bbb;
+}
+
 /* Checkbox modifiers */
 .checkbox .control-indicator {
   border-radius: .25rem;


### PR DESCRIPTION
This addresses Issue https://github.com/mdo/wtf-forms/issues/6 to add a style for `disabled` controls. 
The `readonly` attribute is [not pertinent to radio and checkbox controls](http://stackoverflow.com/a/155301/3003102).

Please disregard the PR into the master branch.