### PR TITLE
Fix checkbox/radio behavior when text is selected in Chrome

### DIFF
--- a/wtf-forms.css
+++ b/wtf-forms.css
@@ -41,6 +41,7 @@
   background-size: 50% 50%;
   background-position: center center;
   background-repeat: no-repeat;
+  pointer-events: none;
   -webkit-user-select: none;
      -moz-user-select: none;
       -ms-user-select: none;


### PR DESCRIPTION
In Chrome, when any text has been selected in the page, clicking on the
faked "indicator" for checkbox/radio buttons does not actually
check/select the input (as the <span> seems to swallow the click somehow
when there is any kind of text selection). Adding `pointer-events:none`
on the indicator allows the click to go through to the label correctly
and trigger the radio/checkbox.

See https://github.com/twbs/bootstrap/issues/18887 - this is a port of
https://github.com/twbs/bootstrap/pull/18935